### PR TITLE
Add connect pad type

### DIFF
--- a/src/footprint/data.rs
+++ b/src/footprint/data.rs
@@ -799,6 +799,8 @@ pub enum PadType {
     Pth,
     /// non-plated through-hole
     NpPth,
+    /// connector
+    Conn,
 }
 
 impl PadType {
@@ -808,6 +810,7 @@ impl PadType {
             "smd" => Ok(PadType::Smd),
             "thru_hole" => Ok(PadType::Pth),
             "np_thru_hole" => Ok(PadType::NpPth),
+            "connect" => Ok(PadType::Conn),
             x => Err(format!("unknown PadType {}", x).into()),
         }
     }

--- a/src/footprint/ser.rs
+++ b/src/footprint/ser.rs
@@ -162,6 +162,7 @@ impl IntoSexp for PadType {
             PadType::Smd => "smd",
             PadType::Pth => "thru_hole",
             PadType::NpPth => "np_thru_hole",
+            PadType::Conn => "connect",
         }.into()
     }
 }


### PR DESCRIPTION
Added `connect` pad type.

Unfortunately there seems to be no official documentation on the `kicad_pcb` file format. I've got this pad type in a part with a pad for special purposes (mainly placing information in the Eco1.User layer).