### PR TITLE
Fix parser escape handling, add test schematic to verify behavior

### DIFF
--- a/src/escaped.rs
+++ b/src/escaped.rs
@@ -1,0 +1,22 @@
+// (c) 2016-2017 Productize SPRL <joost@productize.be>
+
+// Escaped provides a way for types to provide a variant of themselves with changes beneficial
+// to escaping when serialized and written out. For example, Eeschema files require quotes and
+// backslashes to be escaped in serialized string fields.
+pub trait Escaped {
+    fn escaped(&self) -> Self;
+}
+
+// Escape quotes and backslashes in strings
+impl Escaped for String {
+    fn escaped(&self) -> Self {
+        let mut r = String::with_capacity((self.len() as f32 * 1.2) as usize);
+        for c in self.chars() {
+            if c == '"' || c == '\\' {
+                r.push('\\');
+            }
+            r.push(c);
+        }
+        r
+    }
+}

--- a/src/schematic.rs
+++ b/src/schematic.rs
@@ -10,10 +10,11 @@ use std::collections::HashMap;
 
 // get from parent
 use {Bound, BoundingBox, KicadError};
-use util::read_file;
-use str_error;
+use escaped::Escaped;
 use parse_split_quote_aware;
 use parse_split_quote_aware_n;
+use str_error;
+use util::read_file;
 
 /// a Kicad schematic
 #[derive(Debug, Default)]
@@ -781,7 +782,7 @@ impl ComponentField {
 
 impl fmt::Display for ComponentField {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "F {} \"{}\" {} ", self.i, self.value, self.orientation)?;
+        write!(f, "F {} \"{}\" {} ", self.i, self.value.escaped(), self.orientation)?;
         write!(
             f,
             "{:3} {:3} {:3} ",
@@ -794,7 +795,7 @@ impl fmt::Display for ComponentField {
         write!(f, "{}", if self.italic { 'I' } else { 'N' })?;
         write!(f, "{}", if self.bold { 'B' } else { 'N' })?;
         if self.i > 3 {
-            write!(f, " \"{}\"", self.name)?
+            write!(f, " \"{}\"", self.name.escaped())?
         };
         Ok(())
     }

--- a/tests/data/schematic2.sch
+++ b/tests/data/schematic2.sch
@@ -1,0 +1,29 @@
+EESchema Schematic File Version 4
+EELAYER 30 0
+EELAYER END
+$Descr A4 11693 8268
+encoding utf-8
+Sheet 1 1
+Title "Normal"
+Date "Tue 19 May 2015"
+Rev ""
+Comp ""
+Comment1 ""
+Comment2 ""
+Comment3 ""
+Comment4 ""
+$EndDescr
+$Comp
+L Device:R R1
+U 1 1 60F6551B
+P 4500 3000
+F 0 "R1" H 4570 3046 50  0000 L CNN
+F 1 "100" H 4570 2955 50  0000 L CNN
+F 2 "" V 4430 3000 50  0001 C CNN
+F 3 "~" H 4500 3000 50  0001 C CNN
+F 4 "\"Hello, world!\"" H 4500 3000 50  0001 C CNN "QuoteField"
+F 5 "\\backslash\\" H 4500 3000 50  0001 C CNN "\\BackslashField"
+	1    4500 3000
+	1    0    0    -1  
+$EndComp
+$EndSCHEMATC

--- a/tests/schematic2.rs
+++ b/tests/schematic2.rs
@@ -1,0 +1,30 @@
+// (c) 2016-2017 Productize SPRL <joost@productize.be>
+
+extern crate kicad_parse_gen as kicad;
+
+extern crate difference;
+
+use difference::Changeset;
+
+use std::path::PathBuf;
+use std::fmt::Write;
+
+#[test]
+fn parse_and_compare() {
+    let mut file_name = String::new();
+    file_name.push_str(env!("CARGO_MANIFEST_DIR"));
+    file_name.push_str("/tests/data/");
+    file_name.push_str("schematic2.sch");
+    let file_name = PathBuf::from(file_name);
+
+    let content = kicad::read_file(&file_name).unwrap();
+
+    let s = kicad::read_schematic(&file_name).unwrap();
+    let s = format!("{}", s);
+
+    let changeset = Changeset::new(&content, &s, "\n");
+    if changeset.distance > 0 {
+        println!("{}", changeset);
+        assert_eq!(changeset.distance, 0);
+    }
+}


### PR DESCRIPTION
In Eeschema schematic files, backslashes (`\`) and quotes (`"`) are valid characters in many fields, for example names and values in `ComponentField`. These two characters get escaped by KiCad by prepending a backslash (`\\`, `\"`), which the current parsing logic isn't aware of. This set of changes fixes that issue and correctly parses the strings as visible in KiCad. The changes in `parse_split_quote_aware_int` also maintaining the current behavior of not applying special handling to overflowing characters if the field count is limited. Both the limited and unlimited case are covered by a newly added unit test.

For writing the fields out correctly, a new `Escaped` trait is proposed to trivially re-apply escaping to fields that need it via the `.escaped()` method. Right now it is only applied to the name and value entries of `ComponentField`, as that is what the newly added test covers. This behavior can be expanded for more fields (and different KiCad file types) in the future if needed.

cc @luxas @chiplet